### PR TITLE
feat: Update changeset command and release script

### DIFF
--- a/.changeset/moody-icons-raise.md
+++ b/.changeset/moody-icons-raise.md
@@ -1,0 +1,5 @@
+---
+"@fbritoferreira/steam-api": patch
+---
+
+Update changeset command to point to the correct place

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
 
       - run: corepack enable
       - run: pnpm install --frozen-lockfile
-      - run: pnpm publish --provenance --access public
+      - run: pnpm publish --provenance --access public --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -36,5 +36,5 @@ jobs:
       - name: Update jsr version
         run: pnpm run jsr:update-version
       - name: Publish package
-        run: npx jsr publish
+        run: pnpm dlx jsr publish --allow-dirty
         

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lint": "eslint src",
     "changeset": "changeset",
     "lint:fix": "eslint src --fix",
-    "release": "pnpm run build && pnpm run changesets publish",
+    "release": "pnpm run build && pnpm run changeset publish",
     "jsr:update-version": "tsx scripts/update-jsr-version.ts"
   },
   "packageManager": "pnpm@9.0.6",


### PR DESCRIPTION
Update changeset command to point to the correct place and fix typo in release script. Also update publish script to include --no-git-checks flag.