### PR TITLE
build: Add repository field to package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # @fbritoferreira/steam-api
 
+[![JSR](https://jsr.io/badges/@fbritoferreira/steam-api)](https://jsr.io/@fbritoferreira/steam-api)
+[![JSR Score](https://jsr.io/badges/@fbritoferreira/steam-api/score)](https://jsr.io/@fbritoferreira/steam-api)
 __Typesafe wrapper for steam api__
 
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # @fbritoferreira/steam-api
-
 [![JSR](https://jsr.io/badges/@fbritoferreira/steam-api)](https://jsr.io/@fbritoferreira/steam-api)
 [![JSR Score](https://jsr.io/badges/@fbritoferreira/steam-api/score)](https://jsr.io/@fbritoferreira/steam-api)
+
+
 __Typesafe wrapper for steam api__
 
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
     "dist",
     "src/"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/fbritoferreira/steam-api.git"
+  },
   "main": "./dist/mod.ts",
   "module": "./dist/mod.ts",
   "types": "./index.d.ts",


### PR DESCRIPTION
Adds the repository field to package.json with the GitHub URL for the project
repository. This will make it easier for users to access the source code and
contribute to the project.